### PR TITLE
fixed issue where the cheat flag wasn't enabled when turning a cheat mod on during simulation

### DIFF
--- a/PolyTechMain.cs
+++ b/PolyTechMain.cs
@@ -124,6 +124,10 @@ namespace PolyTechFramework
         private void Update()
         {
             PopupQueue.TryShowNextPopup();
+            if (numEnabledCheatMods() > 0 && Bridge.IsSimulating() && !BridgeCheat.m_Cheated){
+                GameStateSim.m_BudgetUsed = Mathf.RoundToInt(Budget.CalculateBridgeCost());
+			    BridgeCheat.m_Cheated = BridgeCheat.CheckForCheating((float)GameStateSim.m_BudgetUsed);
+            }
             if (!flag && globalToggleHotkey.Value.IsDown())
             {
                 flag = true;
@@ -360,6 +364,7 @@ namespace PolyTechFramework
         [HarmonyPrefix]
         private static bool PatchCheats(ref bool __result)
         {
+            ptfInstance.Logger.LogInfo("checking cheats");
             __result = true;
             ptfInstance.modCheated = ptfInstance.modCheated || (modEnabled.Value && numEnabledCheatMods() > 0) || (PolyTechMain.modEnabled.Value && enabledCheatTweaks > 0);
             return !ptfInstance.modCheated;

--- a/PolyTechMain.cs
+++ b/PolyTechMain.cs
@@ -364,7 +364,6 @@ namespace PolyTechFramework
         [HarmonyPrefix]
         private static bool PatchCheats(ref bool __result)
         {
-            ptfInstance.Logger.LogInfo("checking cheats");
             __result = true;
             ptfInstance.modCheated = ptfInstance.modCheated || (modEnabled.Value && numEnabledCheatMods() > 0) || (PolyTechMain.modEnabled.Value && enabledCheatTweaks > 0);
             return !ptfInstance.modCheated;

--- a/PolyTechMain.cs
+++ b/PolyTechMain.cs
@@ -23,7 +23,7 @@ namespace PolyTechFramework
         public new const string
             PluginGuid = "polytech.polytechframework",
             PluginName = "PolyTech Framework",
-            PluginVersion = "0.9.0";
+            PluginVersion = "0.9.1";
         private static BindingList<PolyTechMod>
             noncheatMods = new BindingList<PolyTechMod> { },
             cheatMods = new BindingList<PolyTechMod> { };


### PR DESCRIPTION
This is a **critical** bug fix as it addresses an issue which could be abused to cheat the leaderboards.